### PR TITLE
Security upgrade Debian from bullseye-slim to bookworm-20240904-slim #1

### DIFF
--- a/distribution/Dockerfile
+++ b/distribution/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-20240904-slim
 
 RUN \
   apt-get update && \


### PR DESCRIPTION
**Introduced through**

- e2fsprogs/logsave@1.46.2-2, e2fsprogs@1.46.2-2 and others

**Fixed in**

- e2fsprogs/logsave@1.46.2-2+deb11u1, @1.46.2-2+deb11u1

**Security information**


- Snyk: [CVSS 7.8](https://security.snyk.io/vuln/SNYK-DEBIAN11-E2FSPROGS-2628459) - High Severity
- NVD: [CVSS v3.1 7.8](https://nvd.nist.gov/vuln/detail/CVE-2022-1304) - High Severity
- Debian Security Rating: Not yet assigned